### PR TITLE
Remove intenthandlers obj

### DIFF
--- a/src/utils/build_handlers.js
+++ b/src/utils/build_handlers.js
@@ -7,14 +7,12 @@ function hasAnswerWith(obj) {
 }
 
 export default function buildHandlers (handlersObj, index) {
-  const intentHandlers = handlersObj.intentHandlers; // Error when this doesn't exist
-
-  Object.keys(intentHandlers).map(key => {
-    if (isFunction(intentHandlers[key])) {
-      return intentHandlers[key];
-    } else if (hasAnswerWith(intentHandlers[key])) {
-      const func = intentHandlers[key].answerWith;
-      intentHandlers[key] = function(intent, session, response) {
+  Object.keys(handlersObj).map(key => {
+    if (isFunction(handlersObj[key])) {
+      return handlersObj[key];
+    } else if (hasAnswerWith(handlersObj[key])) {
+      const func = handlersObj[key].answerWith;
+      handlersObj[key] = function(intent, session, response) {
         const args = {intent, session, response};
         index
           .search(intent.slots.query.value)
@@ -23,7 +21,7 @@ export default function buildHandlers (handlersObj, index) {
             func(args);
           });
       };
-      return intentHandlers[key];
+      return handlersObj[key];
     } else {
       throw new Error('Intent handler must either be a function or an object' +
       'with key of "answerWith" which is a function.');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -25,10 +25,8 @@ const args = {
   alexaAppId: 'amzn1.echo-sdk-ams.app.fffff-aaa-fffff-0000',
   defaultIndexName: 'products',
   handlers: {
-    intentHandlers: {
-      HelpHandler: {
-        answerWith () {},
-      },
+    HelpHandler: {
+      answerWith () {},
     },
   },
   algoliasearch,
@@ -87,20 +85,18 @@ describe('handlers', () => {
     search: searchSpy,
   };
   const handlers = {
-    onLaunch() {},
-    intentHandlers: {
-      spyIntent: {
-        answerWith () {},
-      },
-      unChangedIntent () {},
+    LaunchRequest () {},
+    spyIntent: {
+      answerWith () {},
     },
+    unChangedIntent () {},
   };
 
   describe('when intent handler is specified', () => {
     describe('when handler is invoked', () => {
       it('searches Algolia', () => {
         const expectedQuery = 'query';
-        buildHandlers(handlers, index).intentHandlers.spyIntent({slots: {query: {value: expectedQuery}}});
+        buildHandlers(handlers, index).spyIntent({slots: {query: {value: expectedQuery}}});
         expect(searchSpy).toHaveBeenCalledWith(expectedQuery);
       });
     });


### PR DESCRIPTION
All intent handlers at the root of handlers object now. This matches the node SDK versus the old Alexa JS SDK.