### PR TITLE
Move Alexa to base dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,10 +42,8 @@
     }
   ],
   "dependencies": {
+    "alexa-sdk": "^1.0.6",
     "algoliasearch": "^3.20.2"
-  },
-  "peerDependencies": {
-    "alexa-sdk": "^1.0.6"
   },
   "devDependencies": {
     "alexa-sdk": "^1.0.6",


### PR DESCRIPTION
Move from peer dependency. This should ease in development and, at any rate, I think putting it in peer dependencies was getting ahead of ourselves because we haven't yet seen that need.