### PR TITLE
Allow alexaAppID option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ const voiceSearch = algoliaAlexaAdapter({
   algoliaAppId: 'applicationId',
   algoliaApiKey: 'publicSearchKey',
   defaultIndexName: 'products',
+  alexaAppId: 'amzn1.echo-sdk-ams.app.[unique-value-here]',
   handlers: {
     LaunchRequest (launchRequest, session, response) {
       this.emit(':tell', 'Welcome to the skill!')

--- a/README.md
+++ b/README.md
@@ -62,11 +62,12 @@ Follow [this guide](quickstart.md) to quickly start with Algolia and Alexa.
 
 This function accepts a single argument, which is a configuration object.
 
-This configuration object requires:
- - `algoliaAppId`: The app ID from your Algolia application
- - `algoliaApiKey`: The public search key associated with your Algolia application
- - `defaultIndexName`: The index you want to query on Algolia
- - `handlers`: An object with your standard request (`LaunchRequest`, `IntentRequest`, or `SessionEndedRequest`) or built-in and intent handlers
+This configuration object accepts:
+ - `algoliaAppId`: The app ID from your Algolia application **(required)**
+ - `algoliaApiKey`: The public search key associated with your Algolia application **(required)**
+ - `alexaAppId`: Used to verify that the request is coming from your Alexa Skill, responding with an error if defined and requesting application does not match this ID; optional but recommended
+ - `defaultIndexName`: The index you want to query on Algolia **(required)**
+ - `handlers`: An object with your standard request (`LaunchRequest`, `IntentRequest`, or `SessionEndedRequest`) or built-in and intent handlers **(required)**
 
 #### Handlers Configuration
 

--- a/quickstart.md
+++ b/quickstart.md
@@ -112,6 +112,7 @@ const voiceSearch = algoliaAlexaAdapter({
   algoliaAppId: 'applicationId',
   algoliaApiKey: 'publicSearchKey',
   defaultIndexName: 'listings',
+  alexaAppId: 'amzn1.echo-sdk-ams.app.[unique-value-here]',
   handlers: {
     onLaunch(launchRequest, session, response) {
       this.emit(':tell', 'Welcome to the skill!')

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ export default function algoliaAlexaAdapter (opts) {
     algoliaApiKey,
     defaultIndexName,
     handlers,
+    alexaAppId,
     algoliasearch = searchConstructor,
     Alexa = AlexaSDK,
   } = opts;
@@ -39,6 +40,7 @@ export default function algoliaAlexaAdapter (opts) {
 
   skill.handler = function(event, context) {
     const alexa = Alexa.handler(event, context);
+    alexa.appId = alexaAppId;
     alexa.registerHandlers(buildHandlers(handlers, index));
     alexa.execute();
   };


### PR DESCRIPTION
This will allow for validation on the Skill that it is sent from the correct actor and [is a best practice recommended by Amazon](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/handling-requests-sent-by-alexa#verifying-that-the-request-is-intended-for-your-service).

The ASK SDK can handle an `undefined` value, so we do not handle that inside here.