### PR TITLE
Search params merging

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 lib/
+src/version.js

--- a/.npmignore
+++ b/.npmignore
@@ -2,5 +2,7 @@
 .eslintignore
 .eslintrc.js
 src/
+test/
+quickstart.md
 !lib/
 !lib/utils/

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ const voiceSearch = algoliaAlexaAdapter({
   defaultIndexName: 'products',
   alexaAppId: 'amzn1.echo-sdk-ams.app.[unique-value-here]',
   handlers: {
-    LaunchRequest (launchRequest, session, response) {
+    LaunchRequest () {
       this.emit(':tell', 'Welcome to the skill!')
     },
     SearchProductIntent: {
@@ -42,8 +42,14 @@ const voiceSearch = algoliaAlexaAdapter({
           this.emit(':tell', 'We could find no products. Please try again.');
         }
       },
+      params: {
+        hitsPerPage: 1,
+        filters: function (requestBody) {
+          return `brand:${requestBody.request.intent.slots.brand.value}`;
+        }
+      },
     },
-    CustomHelpIntent: function (intent, session, response) {
+    CustomHelpIntent: function () {
       const speechOutput = 'Find one of 10,000 products from the Product Store, powered by Algolia.';
       this.emit(':ask', speechOutput);
     },

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ const voiceSearch = algoliaAlexaAdapter({
       const speechOutput = 'Find one of 10,000 products from the Product Store, powered by Algolia.';
       this.emit(':ask', speechOutput);
     },
+    Unhandled: function () {
+      this.emit(':ask', 'Look for products in the Product Store.');
+    },
   },
 });
 

--- a/quickstart.md
+++ b/quickstart.md
@@ -53,6 +53,21 @@ Now that we have our Lambda function set up, we need to set up our Alexa Skill t
     {
       "intent": "CustomHelpIntent",
       "slots": []
+    },
+    {
+      "intent": "AMAZON.CancelIntent"
+    },
+    {
+      "intent": "AMAZON.StopIntent"
+    },
+    {
+      "intent": "AMAZON.StartOverIntent"
+    },
+    {
+      "intent": "AMAZON.NoIntent"
+    },
+    {
+      "intent": "AMAZON.YesIntent"
     }
   ]
 }

--- a/quickstart.md
+++ b/quickstart.md
@@ -51,8 +51,11 @@ Now that we have our Lambda function set up, we need to set up our Alexa Skill t
       ]
     },
     {
-      "intent": "CustomHelpIntent",
+      "intent": "FreshnessIntent",
       "slots": []
+    },
+    {
+      "intent": "AMAZON.HelpIntent"
     },
     {
       "intent": "AMAZON.CancelIntent"
@@ -73,7 +76,7 @@ Now that we have our Lambda function set up, we need to set up our Alexa Skill t
 }
 ```
 
-An intent like our `CustomHelpIntent`, which has a very simple interaction model (e.g. `How can I use this skill?`), has no slots.
+An intent like our `FreshnessIntent`, which has a very simple interaction model (e.g. `When were the listings last updated?`), has no slots.
 
 Most intents, however, will have slots. A slot is like an argument for the intent. For example, our `GetListingsIntent` could be invoked by `What homes are available for sale in Houston?` or `What homes are available for sale in Tulsa?`. New slot types are being added often and more information can be [found here](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/built-in-intent-ref/slot-type-reference) and [here](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/migrating-to-the-improved-built-in-and-custom-slot-types).
 
@@ -92,22 +95,10 @@ GetListingsIntent {query} homes available
 GetListingsIntent {query} homes for sale
 GetListingsIntent what homes are for sale in {query}
 
-CustomHelpIntent help
-CustomHelpIntent help me
-CustomHelpIntent what can I ask you
-CustomHelpIntent get help
-CustomHelpIntent to help
-CustomHelpIntent to help me
-CustomHelpIntent what commands can I ask
-CustomHelpIntent what commands can I say
-CustomHelpIntent what can I do
-CustomHelpIntent what can I use this for
-CustomHelpIntent what questions can I ask
-CustomHelpIntent what can you do
-CustomHelpIntent what do you do
-CustomHelpIntent how do I use you
-CustomHelpIntent how can I use you
-CustomHelpIntent what can you tell me
+FreshnessIntent when were the listings last updated
+FreshnessIntent when the listings were last updated
+FreshnessIntent to tell me when listings were updated last
+FreshnessIntent the date of the last update
 ```
 
 Here we have the name of the intent on the left, the utterance on the right, and the slot in curly braces. You can find more information on sample utterances in [the Amazon documentation](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/defining-the-voice-interface#h2_sample_utterances).

--- a/quickstart.md
+++ b/quickstart.md
@@ -47,6 +47,10 @@ Now that we have our Lambda function set up, we need to set up our Alexa Skill t
         {
           "name": "query",
           "type": "AMAZON.US_CITY"
+        },
+        {
+          "name": "available",
+          "type": "AMAZON.DATE"
         }
       ]
     },
@@ -78,15 +82,15 @@ Now that we have our Lambda function set up, we need to set up our Alexa Skill t
 
 An intent like our `FreshnessIntent`, which has a very simple interaction model (e.g. `When were the listings last updated?`), has no slots.
 
-Most intents, however, will have slots. A slot is like an argument for the intent. For example, our `GetListingsIntent` could be invoked by `What homes are available for sale in Houston?` or `What homes are available for sale in Tulsa?`. New slot types are being added often and more information can be [found here](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/built-in-intent-ref/slot-type-reference) and [here](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/migrating-to-the-improved-built-in-and-custom-slot-types).
+Most intents, however, will have slots. A slot is like an argument for the intent. For example, our `GetListingsIntent` could be invoked by `What homes are available for sale in Houston?`, `What homes are available for sale in Tulsa?`, or `What new homes in Little Rock are available starting next week?`. New slot types are being added often and more information can be [found here](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/built-in-intent-ref/slot-type-reference) and [here](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/migrating-to-the-improved-built-in-and-custom-slot-types).
 
-**Very important to note**: currently for the Alexa adaptor the slot name **must** be `query` and we can have just the single slot. This is what will be passed to Algolia and will be searched for in the specified index.
+**Very important to note**: currently for the Alexa adaptor the slot name for the full text search **must** be `query`. This is what will be passed to Algolia and will be searched for in the specified index. Other slots can be used for search parameters, as we'll see below.
 
 Fill out the custom slot types if necessary, and follow with the sample utterances.
 
 ### Sample utterances
 
-Sample utterances are the "training set" for Alexa to understand how people might interact with the skill. For our intent schema above, we might have the following sample utterances:
+Sample utterances are the "training set" for Alexa to understand how people might interact with the skill. For our intent schema above, we might have the following sample utterances (truncated for length):
 
 ```
 GetListingsIntent what homes are available in {query}
@@ -94,6 +98,10 @@ GetListingsIntent homes in {query}
 GetListingsIntent {query} homes available
 GetListingsIntent {query} homes for sale
 GetListingsIntent what homes are for sale in {query}
+GetListingsIntent what homes are available in {query} available starting {available}
+GetListingsIntent homes in {query} available starting {available}
+GetListingsIntent {query} homes available available starting {available}
+GetListingsIntent {query} homes for sale available starting {available}
 
 FreshnessIntent when were the listings last updated
 FreshnessIntent when the listings were last updated
@@ -101,7 +109,7 @@ FreshnessIntent to tell me when listings were updated last
 FreshnessIntent the date of the last update
 ```
 
-Here we have the name of the intent on the left, the utterance on the right, and the slot in curly braces. You can find more information on sample utterances in [the Amazon documentation](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/defining-the-voice-interface#h2_sample_utterances).
+Here we have the name of the intent on the left, the utterance on the right, and the slot(s) in curly braces. You can find more information on sample utterances in [the Amazon documentation](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/defining-the-voice-interface#h2_sample_utterances).
 
 Save that, and on the next screen select the radio button for **AWS Lambda ARN (Amazon Resource Name)**, select the region you selected for your Lambda function, and paste in the ARN from your Lambda function. The ARN can be found in the upper-righthand corner on the Lambda function page.
 
@@ -131,9 +139,14 @@ const voiceSearch = algoliaAlexaAdapter({
           this.emit(':tell', 'We could find no listings. Please try again.');
         }
       },
+      params: {
+        filters: function (requestBody) {
+          return `available:${requestBody.request.intent.slots.available.value}`;
+        }
+      },
     },
-    CustomHelpIntent: function (intent, session, response) {
-      const speechOutput = 'Find one of thousands of listings from the Listing Store, powered by Algolia.';
+    FreshnessIntent: function (intent, session, response) {
+      const speechOutput = 'Listings on the listing store are updated every day. What city are you looking for?';
       this.emit(':ask', speechOutput);
     },
   },

--- a/src/utils/build_handlers.js
+++ b/src/utils/build_handlers.js
@@ -1,8 +1,8 @@
-import {isFunction, isObject} from './is_of_type.js';
+import {isFunction} from './is_of_type.js';
 import buildParams from './build_params.js';
 
 function hasAnswerWith(obj) {
-  return isObject(obj) && obj.answerWith;
+  return obj && obj.answerWith !== undefined;
 }
 
 export default function buildHandlers (handlersObj, index) {

--- a/src/utils/build_handlers.js
+++ b/src/utils/build_handlers.js
@@ -1,4 +1,5 @@
 import {isFunction, isObject} from './is_of_type.js';
+import buildParams from './build_params.js';
 
 function hasAnswerWith(obj) {
   return isObject(obj) && obj.answerWith;
@@ -10,18 +11,22 @@ export default function buildHandlers (handlersObj, index) {
       return handlersObj[key];
     } else if (hasAnswerWith(handlersObj[key])) {
       const func = handlersObj[key].answerWith;
+      const paramsObj = handlersObj[key].params;
+
       handlersObj[key] = function() {
         const args = {event: this.event};
+        const params = buildParams(paramsObj, this.event);
         index
-          .search(args.event.request.intent.slots.query.value)
+          .search(args.event.request.intent.slots.query.value, params)
           .then((results, err) => {
             Object.assign(args, {err, results});
             func.call(this, args);
           });
       };
+
       return handlersObj[key];
     } else {
-      throw new Error('Intent handler must either be a function or an object' +
+      throw new Error('Intent handler must either be a function or an object ' +
       'with key of "answerWith" which is a function.');
     }
   });

--- a/src/utils/build_handlers.js
+++ b/src/utils/build_handlers.js
@@ -1,9 +1,7 @@
-function isFunction(obj) {
-  return typeof obj === 'function';
-}
+import {isFunction, isObject} from './is_of_type.js';
 
 function hasAnswerWith(obj) {
-  return typeof obj === 'object' && obj.answerWith;
+  return isObject(obj) && obj.answerWith;
 }
 
 export default function buildHandlers (handlersObj, index) {

--- a/src/utils/build_params.js
+++ b/src/utils/build_params.js
@@ -1,0 +1,21 @@
+import {isObject, isFunction} from './is_of_type.js';
+
+export default function buildParams (params, event) {
+  if (params === undefined || params === null) {
+    return {};
+  }
+
+  if (!isObject(params)) {
+    throw new Error('params must be an object');
+  }
+
+  for (const prop in params) {
+    if (params.hasOwnProperty(prop)) {
+      if (isFunction(prop)) {
+        params[prop] = params[prop](event);
+      }
+    }
+  }
+
+  return params;
+}

--- a/src/utils/build_params.js
+++ b/src/utils/build_params.js
@@ -11,7 +11,7 @@ export default function buildParams (params, event) {
 
   for (const prop in params) {
     if (params.hasOwnProperty(prop)) {
-      if (isFunction(prop)) {
+      if (isFunction(params[prop])) {
         params[prop] = params[prop](event);
       }
     }

--- a/src/utils/is_of_type.js
+++ b/src/utils/is_of_type.js
@@ -1,0 +1,10 @@
+function isOfType(signature) {
+  return function(param) {
+    return Object.prototype.toString.call(param) === signature;
+  };
+}
+
+const isObject = isOfType('[object Object]');
+const isFunction = isOfType('[object Function]');
+
+export {isOfType, isObject, isFunction};

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -8,6 +8,7 @@ import buildHandlers from '../src/utils/build_handlers.js';
 
 const algoliasearch = jest.fn(() => ({
   initIndex () {},
+  addAlgoliaAgent () {},
 }));
 
 const Alexa = {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -85,12 +85,45 @@ describe('handlers', () => {
   const index = {
     search: searchSpy,
   };
+
   const handlers = {
     LaunchRequest () {},
     spyIntent: {
       answerWith () {},
     },
+    withParamsIntent: {
+      answerWith () {},
+      params: {
+        page: 10,
+      },
+    },
+    withParamsWithFunctionIntent: {
+      answerWith () {},
+      params: {
+        page (requestBody) {
+          return requestBody.request.intent.slots.page.value;
+        },
+      },
+    },
     unChangedIntent () {},
+  };
+  const builtHandlers = buildHandlers(handlers, index);
+  const expectedQuery = 'query';
+  const scope = {
+    event: {
+      request: {
+        intent: {
+          slots: {
+            query: {
+              value: expectedQuery,
+            },
+            page: {
+              value: 5,
+            },
+          },
+        },
+      },
+    },
   };
 
   beforeEach(() => {
@@ -98,14 +131,49 @@ describe('handlers', () => {
   });
 
   describe('when intent handler is specified', () => {
-    describe('with answerWith', () => {
-      describe('when handler is invoked', () => {
-        it('searches Algolia', () => {
-          const expectedQuery = 'query';
-          const scope = {event: {request: {intent: {slots: {query: {value: expectedQuery}}}}}};
-          const builtHandlers = buildHandlers(handlers, index);
-          builtHandlers.spyIntent.call(scope);
-          expect(searchSpy).toHaveBeenCalledWith(expectedQuery);
+    describe('is an object', () => {
+      describe('with answerWith', () => {
+        describe('without params to merge', () => {
+          describe('when handler is invoked', () => {
+            it('searches Algolia', () => {
+              const expectedParams = {};
+
+              builtHandlers.spyIntent.call(scope);
+
+              expect(searchSpy).toHaveBeenCalledWith(expectedQuery, expectedParams);
+            });
+          });
+        });
+
+        describe('with params to merge', () => {
+          describe('when handler is invoked', () => {
+            it('searches Algolia with params', () => {
+              const expectedParams = {page: 10};
+
+              builtHandlers.withParamsIntent.call(scope);
+
+              expect(searchSpy).toHaveBeenCalledWith(expectedQuery, expectedParams);
+            });
+          });
+
+          describe('with params with function', () => {
+            const expectedParams = {page: 5};
+
+            builtHandlers.withParamsWithFunctionIntent.call(scope);
+
+            expect(searchSpy).toHaveBeenCalledWith(expectedQuery, expectedParams);
+          });
+        });
+      });
+
+      describe('without answerWith', () => {
+        it('throws an error', () => {
+          const newHandlers = {withoutAnswerWithIntent: {}};
+          Object.assign(newHandlers, handlers);
+
+          expect(() => {
+            buildHandlers(newHandlers, index);
+          }).toThrow();
         });
       });
     });

--- a/test/utils/build_params.test.js
+++ b/test/utils/build_params.test.js
@@ -58,4 +58,34 @@ describe('buildParams', () => {
       }).toThrow();
     });
   });
+
+  describe('when an object is specified', () => {
+    describe('when values are all strings', () => {
+      it('returns the object as is', () => {
+        const params = {
+          page: 10,
+          hitsPerPage: 12,
+        };
+        expect(buildParams(params)).toEqual(params);
+      });
+    });
+
+    describe('when a value is a function', () => {
+      it('returns as a value the return value of that function', () => {
+        const params = {
+          page: 10,
+          hitsPerPage (requestBody) {
+            return requestBody.request.intent.slots.num.value;
+          },
+        };
+        const body = {request: {intent: {slots: {num: {value: 12}}}}};
+        const expected = {
+          page: 10,
+          hitsPerPage: 12,
+        };
+
+        expect(buildParams(params, body)).toEqual(expected);
+      });
+    });
+  });
 });

--- a/test/utils/build_params.test.js
+++ b/test/utils/build_params.test.js
@@ -1,0 +1,61 @@
+/* global
+  it, expect, describe
+*/
+
+import buildParams from '../../src/utils/build_params.js';
+
+describe('buildParams', () => {
+  describe('when nothing is specified', () => {
+    it('returns an empty object if undefined', () => {
+      expect(buildParams(undefined)).toEqual({});
+    });
+
+    it('returns an empty object if null', () => {
+      expect(buildParams(null)).toEqual({});
+    });
+  });
+
+  describe('when a non-object something is specified', () => {
+    it('throws for a string', () => {
+      expect(() => {
+        buildParams('');
+      }).toThrow();
+    });
+
+    it('throws for a boolean', () => {
+      expect(() => {
+        buildParams(true);
+      }).toThrow();
+    });
+
+    it('throws for an array', () => {
+      expect(() => {
+        buildParams([]);
+      }).toThrow();
+    });
+
+    it('throws for a number', () => {
+      expect(() => {
+        buildParams(1);
+      }).toThrow();
+    });
+
+    it('throws for a set', () => {
+      expect(() => {
+        buildParams(new Set());
+      }).toThrow();
+    });
+
+    it('throws for a map', () => {
+      expect(() => {
+        buildParams(new Map());
+      }).toThrow();
+    });
+
+    it('throws for a function', () => {
+      expect(() => {
+        buildParams(() => {});
+      }).toThrow();
+    });
+  });
+});

--- a/test/utils/is_of_type.test.js
+++ b/test/utils/is_of_type.test.js
@@ -21,11 +21,11 @@ describe('isObject', () => {
 });
 
 describe('isFunction', () => {
-  it('return true if an object', () => {
+  it('return true if a function', () => {
     expect(isFunction(() => {})).toEqual(true);
   });
 
-  it('return false if not an object', () => {
+  it('return false if not a function', () => {
     expect(isFunction({})).toEqual(false);
   });
 });

--- a/test/utils/is_of_type.test.js
+++ b/test/utils/is_of_type.test.js
@@ -1,0 +1,31 @@
+/* global
+  it, expect, describe
+*/
+
+import {isOfType, isObject, isFunction} from '../../src/utils/is_of_type.js';
+
+describe('isOfType', () => {
+  it('returns a function', () => {
+    expect(isOfType('[object Object]')).toBeInstanceOf(Function);
+  });
+});
+
+describe('isObject', () => {
+  it('return true if an object', () => {
+    expect(isObject({})).toEqual(true);
+  });
+
+  it('return false if not an object', () => {
+    expect(isObject([])).toEqual(false);
+  });
+});
+
+describe('isFunction', () => {
+  it('return true if an object', () => {
+    expect(isFunction(() => {})).toEqual(true);
+  });
+
+  it('return false if not an object', () => {
+    expect(isFunction({})).toEqual(false);
+  });
+});


### PR DESCRIPTION
This change allows for merging of params into the search for any intent that leverages Algolia. With this, I see the adapter to be 1.0-ready (on the Algolia side).

Behavior:
 - Intent must use Algolia (i.e. provide an object with `answerWith` function)
 - Params must have a key in that object named `params`
 - Any param that provides a function will receive the request body from Alexa and must return a valid param
 - Any param that is not a function will be untouched

No new dependencies.