### PR TITLE
Add string localization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ Specify a key-value pair where the key is the intent handler name and the value 
 
 Specify a key-value pair where the key is the intent handler name and the value is an object. That object contains a function `answerWith` which will be invoked following the Algolia search. This accepts one argument: an object with values for the keys of `results` from Algolia and `event` from the Alexa service.
 
+#### Localization
+
+You can set your localization strings via the `languageStrings` option on the top level object. Within the intents, you will invoke them with `this.t` as normal. [See here for more information](https://github.com/alexa/alexa-skills-kit-sdk-for-nodejs#adding-multi-language-support-for-skill) on localizing a skill.
+
 ## Dev
 
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ export default function algoliaAlexaAdapter (opts) {
     defaultIndexName,
     handlers,
     alexaAppId,
+    languageStrings,
     algoliasearch = searchConstructor,
     Alexa = AlexaSDK,
   } = opts;
@@ -43,6 +44,9 @@ export default function algoliaAlexaAdapter (opts) {
   skill.handler = function(event, context) {
     const alexa = Alexa.handler(event, context);
     alexa.appId = alexaAppId;
+    if (languageStrings) {
+      alexa.resources = languageStrings;
+    }
     alexa.registerHandlers(buildHandlers(handlers, index));
     alexa.execute();
   };


### PR DESCRIPTION
Add support for localization strings.

Simple one, this:
`languageStrings` can be passed as an option on the top-level object. It is set as `resources` on the `alexa` object. [See here](https://github.com/alexa/alexa-skills-kit-sdk-for-nodejs#adding-multi-language-support-for-skill).