### PR TITLE
State handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,35 +95,9 @@ Specify a key-value pair where the key is the intent handler name and the value 
 
 #### State Management
 
-State-based routing of intents can be done in a couple ways.
+States in the Alexa Skills Kit represent, roughly, different steps in the skill flow process. For example, there can be a state for starting a game, a state for being in the middle of a turn, and an empty state that represents the skill launch. You can [read more here](https://github.com/alexa/alexa-skills-kit-sdk-for-nodejs#making-skill-state-management-simpler) at the Alexa Skills Kit SDK README.
 
-##### Manual Definition
-
-The simplest way is to append the state to the intent (e.g. `AMAZON.YesIntent_SEARCHINGMODE`) and define your handlers as above. This is, in fact, the way that the Alexa Skills Kit SDK for Node.js does it in the background.
-
-Your handlers would look something like this (truncated for brevity):
-
-```javascript
-const states = {
-  SEARCHINGMODE: '_SEARCHINGMODE'
-};
-
-const handlers = {
-  NewSession () {
-    this.handler.state = states.SEARCHINGMODE;
-    this.emit(':ask', 'Welcome to the skill! What product would you like to find?');
-  },
-  ['AMAZON.YesIntent' + states.SEARCHINGMODE]: {
-    answerWith (data) {
-      // Do something...
-    }
-  }
-};
-```
-
-##### Providing an Array
-
-Another way is to provide an array of objects, with each that you want tied to a specific state to have a key of `state`:
+To define your states for each handler, provide an array of objects, with each that you want tied to a specific state to have a key of `state`:
 
 ```javascript
 const states = {

--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ Specify a key-value pair where the key is the intent handler name and the value 
 
 Specify a key-value pair where the key is the intent handler name and the value is an object. That object contains a function `answerWith` which will be invoked following the Algolia search. This accepts one argument: an object with values for the keys of `results` from Algolia and `event` from the Alexa service.
 
+#### Localization
+
+You can set your localization strings via the `languageStrings` option on the top level object. Within the intents, you will invoke them with `this.t` as normal. [See here for more information](https://github.com/alexa/alexa-skills-kit-sdk-for-nodejs#adding-multi-language-support-for-skill) on localizing a skill.
+
 ## Dev
 
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,8 @@ export default function algoliaAlexaAdapter (opts) {
     Alexa = AlexaSDK,
   } = opts;
 
+  const _StateString = Alexa.StateString;
+
   if (algoliaAppId === undefined) {
     throw new Error('Must initialize with algoliaAppId');
   }
@@ -46,7 +48,7 @@ export default function algoliaAlexaAdapter (opts) {
     if (languageStrings) {
       alexa.resources = languageStrings;
     }
-    alexa.registerHandlers(buildHandlers(handlers, index));
+    alexa.registerHandlers(...buildHandlers(handlers, index, _StateString));
     alexa.execute();
   };
 

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ export default function algoliaAlexaAdapter (opts) {
     defaultIndexName,
     handlers,
     alexaAppId,
+    languageStrings,
     algoliasearch = searchConstructor,
     Alexa = AlexaSDK,
   } = opts;
@@ -43,6 +44,9 @@ export default function algoliaAlexaAdapter (opts) {
   skill.handler = function(event, context) {
     const alexa = Alexa.handler(event, context);
     alexa.appId = alexaAppId;
+    if (languageStrings) {
+      alexa.resources = languageStrings;
+    }
     alexa.registerHandlers(buildHandlers(handlers, index));
     alexa.execute();
   };

--- a/src/index.js
+++ b/src/index.js
@@ -41,8 +41,8 @@ export default function algoliaAlexaAdapter (opts) {
   client.addAlgoliaAgent(`Alexa Skills Kit Adapter ${versionNumber}`);
   const index = client.initIndex(defaultIndexName);
 
-  skill.handler = function(event, context) {
-    const alexa = Alexa.handler(event, context);
+  skill.handler = function(event, context, callback) {
+    const alexa = Alexa.handler(event, context, callback);
     alexa.appId = alexaAppId;
     if (languageStrings) {
       alexa.resources = languageStrings;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 import AlexaSDK from 'alexa-sdk';
-import EventEmitter from 'events';
 import searchConstructor from 'algoliasearch';
 import buildHandlers from './utils/build_handlers.js';
 import versionNumber from './version.js';
@@ -36,7 +35,7 @@ export default function algoliaAlexaAdapter (opts) {
     throw new Error('Must initialize with handlers');
   }
 
-  const skill = new EventEmitter();
+  const skill = {};
   const client = algoliasearch(algoliaAppId, algoliaApiKey);
   client.addAlgoliaAgent(`Alexa Skills Kit Adapter ${versionNumber}`);
   const index = client.initIndex(defaultIndexName);

--- a/src/utils/build_handlers.js
+++ b/src/utils/build_handlers.js
@@ -36,8 +36,6 @@ function buildFromObject(obj, index, stateString) {
     }
   }, {});
 
-  delete result.stateString;
-
   Object.defineProperty(result, stateString, {
     value: obj.state || '',
   });

--- a/src/utils/build_handlers.js
+++ b/src/utils/build_handlers.js
@@ -36,7 +36,11 @@ function buildFromObject(obj, index, STATE_STRING) {
     }
   }, {});
 
-  result[STATE_STRING] = obj.state;
+  delete result.STATE_STRING;
+
+  Object.defineProperty(result, STATE_STRING, {
+    value: obj.state || '',
+  });
 
   return [result];
 }

--- a/src/utils/build_handlers.js
+++ b/src/utils/build_handlers.js
@@ -1,19 +1,24 @@
-import {isFunction} from './is_of_type.js';
+import {isFunction, isArray, isObject} from './is_of_type.js';
 import buildParams from './build_params.js';
 
 function hasAnswerWith(obj) {
   return obj && obj.answerWith !== undefined;
 }
 
-export default function buildHandlers (handlersObj, index) {
-  Object.keys(handlersObj).map(key => {
-    if (isFunction(handlersObj[key])) {
-      return handlersObj[key];
-    } else if (hasAnswerWith(handlersObj[key])) {
-      const func = handlersObj[key].answerWith;
-      const paramsObj = handlersObj[key].params;
+function buildFromObject(obj, index, STATE_STRING) {
+  const result = Object.keys(obj).reduce((object, key) => {
+    if (key === 'state') {
+      return object;
+    }
 
-      handlersObj[key] = function() {
+    if (isFunction(obj[key])) {
+      object[key] = obj[key];
+      return object;
+    } else if (hasAnswerWith(obj[key])) {
+      const func = obj[key].answerWith;
+      const paramsObj = obj[key].params;
+
+      object[key] = function() {
         const args = {event: this.event};
         const params = buildParams(paramsObj, this.event);
         index
@@ -24,12 +29,32 @@ export default function buildHandlers (handlersObj, index) {
           });
       };
 
-      return handlersObj[key];
+      return object;
     } else {
       throw new Error('Intent handler must either be a function or an object ' +
       'with key of "answerWith" which is a function.');
     }
-  });
+  }, {});
 
-  return handlersObj;
+  result[STATE_STRING] = obj.state;
+
+  return [result];
+}
+
+function buildFromArray(arr, index, STATE_STRING) {
+  return arr.map(obj => buildFromObject(obj, index, STATE_STRING)[0]);
+}
+
+export default function buildHandlers (handlers, index, STATE_STRING) {
+  let result;
+
+  if (isArray(handlers)) {
+    result = buildFromArray(handlers, index, STATE_STRING);
+  } else if (isObject(handlers)) {
+    result = buildFromObject(handlers, index, STATE_STRING);
+  } else {
+    throw new Error('Handlers must be either an array or an object.');
+  }
+
+  return result;
 }

--- a/src/utils/build_handlers.js
+++ b/src/utils/build_handlers.js
@@ -5,7 +5,7 @@ function hasAnswerWith(obj) {
   return obj && obj.answerWith !== undefined;
 }
 
-function buildFromObject(obj, index, STATE_STRING) {
+function buildFromObject(obj, index, stateString) {
   const result = Object.keys(obj).reduce((object, key) => {
     if (key === 'state') {
       return object;
@@ -36,26 +36,26 @@ function buildFromObject(obj, index, STATE_STRING) {
     }
   }, {});
 
-  delete result.STATE_STRING;
+  delete result.stateString;
 
-  Object.defineProperty(result, STATE_STRING, {
+  Object.defineProperty(result, stateString, {
     value: obj.state || '',
   });
 
   return [result];
 }
 
-function buildFromArray(arr, index, STATE_STRING) {
-  return arr.map(obj => buildFromObject(obj, index, STATE_STRING)[0]);
+function buildFromArray(arr, index, stateString) {
+  return arr.map(obj => buildFromObject(obj, index, stateString)[0]);
 }
 
-export default function buildHandlers (handlers, index, STATE_STRING) {
+export default function buildHandlers (handlers, index, stateString) {
   let result;
 
   if (isArray(handlers)) {
-    result = buildFromArray(handlers, index, STATE_STRING);
+    result = buildFromArray(handlers, index, stateString);
   } else if (isObject(handlers)) {
-    result = buildFromObject(handlers, index, STATE_STRING);
+    result = buildFromObject(handlers, index, stateString);
   } else {
     throw new Error('Handlers must be either an array or an object.');
   }

--- a/src/utils/build_handlers.js
+++ b/src/utils/build_handlers.js
@@ -48,15 +48,11 @@ function buildFromArray(arr, index, stateString) {
 }
 
 export default function buildHandlers (handlers, index, stateString) {
-  let result;
-
   if (isArray(handlers)) {
-    result = buildFromArray(handlers, index, stateString);
+    return buildFromArray(handlers, index, stateString);
   } else if (isObject(handlers)) {
-    result = buildFromObject(handlers, index, stateString);
+    return buildFromObject(handlers, index, stateString);
   } else {
     throw new Error('Handlers must be either an array or an object.');
   }
-
-  return result;
 }

--- a/src/utils/is_of_type.js
+++ b/src/utils/is_of_type.js
@@ -6,6 +6,6 @@ function isOfType(signature) {
 
 const isObject = isOfType('[object Object]');
 const isFunction = isOfType('[object Function]');
-const isArray = isOfType('[object Array]');
+const isArray = Array.isArray;
 
 export {isOfType, isObject, isFunction, isArray};

--- a/src/utils/is_of_type.js
+++ b/src/utils/is_of_type.js
@@ -6,5 +6,6 @@ function isOfType(signature) {
 
 const isObject = isOfType('[object Object]');
 const isFunction = isOfType('[object Function]');
+const isArray = isOfType('[object Array]');
 
-export {isOfType, isObject, isFunction};
+export {isOfType, isObject, isFunction, isArray};

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,10 +1,9 @@
 /* global
-  it, expect, describe, jest, beforeEach
+  it, expect, describe, jest
 */
 
 import algoliaAlexaAdapter from '../src/index.js';
 import copyExcept from '../src/utils/copy_except.js';
-import buildHandlers from '../src/utils/build_handlers.js';
 
 const algoliasearch = jest.fn(() => ({
   initIndex () {},
@@ -77,112 +76,5 @@ describe('constructor', () => {
 
   it('returns an object', () => {
     expect(algoliaAlexaAdapter(args)).toEqual(expect.any(Object));
-  });
-});
-
-describe('handlers', () => {
-  const searchSpy = jest.fn(() => Promise.resolve());
-  const index = {
-    search: searchSpy,
-  };
-
-  const handlers = {
-    LaunchRequest () {},
-    spyIntent: {
-      answerWith () {},
-    },
-    withParamsIntent: {
-      answerWith () {},
-      params: {
-        page: 10,
-      },
-    },
-    withParamsWithFunctionIntent: {
-      answerWith () {},
-      params: {
-        page (requestBody) {
-          return requestBody.request.intent.slots.page.value;
-        },
-      },
-    },
-    unChangedIntent () {},
-  };
-  const builtHandlers = buildHandlers(handlers, index);
-  const expectedQuery = 'query';
-  const scope = {
-    event: {
-      request: {
-        intent: {
-          slots: {
-            query: {
-              value: expectedQuery,
-            },
-            page: {
-              value: 5,
-            },
-          },
-        },
-      },
-    },
-  };
-
-  beforeEach(() => {
-    searchSpy.mockClear();
-  });
-
-  describe('when intent handler is specified', () => {
-    describe('is an object', () => {
-      describe('with answerWith', () => {
-        describe('without params to merge', () => {
-          describe('when handler is invoked', () => {
-            it('searches Algolia', () => {
-              const expectedParams = {};
-
-              builtHandlers.spyIntent.call(scope);
-
-              expect(searchSpy).toHaveBeenCalledWith(expectedQuery, expectedParams);
-            });
-          });
-        });
-
-        describe('with params to merge', () => {
-          describe('when handler is invoked', () => {
-            it('searches Algolia with params', () => {
-              const expectedParams = {page: 10};
-
-              builtHandlers.withParamsIntent.call(scope);
-
-              expect(searchSpy).toHaveBeenCalledWith(expectedQuery, expectedParams);
-            });
-          });
-
-          describe('with params with function', () => {
-            const expectedParams = {page: 5};
-
-            builtHandlers.withParamsWithFunctionIntent.call(scope);
-
-            expect(searchSpy).toHaveBeenCalledWith(expectedQuery, expectedParams);
-          });
-        });
-      });
-
-      describe('without answerWith', () => {
-        it('throws an error', () => {
-          const newHandlers = {withoutAnswerWithIntent: {}};
-          Object.assign(newHandlers, handlers);
-
-          expect(() => {
-            buildHandlers(newHandlers, index);
-          }).toThrow();
-        });
-      });
-    });
-
-    describe('without answerWith', () => {
-      it('does not search Algolia', () => {
-        buildHandlers(handlers, index).unChangedIntent();
-        expect(searchSpy).not.toHaveBeenCalled();
-      });
-    });
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -33,6 +33,75 @@ const args = {
   Alexa,
 };
 
+const state = 'START_STATE';
+const argsWithState = {
+  algoliaAppId: 'APP_ID',
+  algoliaApiKey: 'API_KEY',
+  alexaAppId: 'amzn1.echo-sdk-ams.app.fffff-aaa-fffff-0000',
+  defaultIndexName: 'products',
+  handlers: [{
+    HelpHandler: {
+      answerWith () {},
+    },
+  }, {
+    state,
+    HelpHandler: {
+      answerWith () {},
+    },
+    'AMAZON.YesIntent' () {},
+  }],
+  algoliasearch,
+  Alexa,
+};
+
+const req = {
+  session: {
+    new: false,
+    sessionId: 'amzn1.echo-api.session.[unique-value-here]',
+    attributes: {},
+    user: {
+      userId: 'amzn1.ask.account.[unique-value-here]',
+    },
+    application: {
+      applicationId: 'amzn1.ask.skill.[unique-value-here]',
+    },
+  },
+  version: '1.0',
+  request: {
+    locale: 'en-US',
+    timestamp: '2016-10-27T21:06:28Z',
+    type: 'IntentRequest',
+    requestId: 'amzn1.echo-api.request.[unique-value-here]',
+    intent: {
+      slots: {
+        query: {
+          name: 'query',
+          value: 'snowball',
+        },
+      },
+      name: 'AMAZON.YesIntent',
+    },
+  },
+  context: {
+    AudioPlayer: {
+      playerActivity: 'IDLE',
+    },
+    System: {
+      device: {
+        supportedInterfaces: {
+          AudioPlayer: {},
+        },
+      },
+      application: {
+        applicationId: 'amzn1.ask.skill.[unique-value-here]',
+      },
+      user: {
+        userId: 'amzn1.ask.account.[unique-value-here]',
+      },
+    },
+  },
+};
+
 describe('constructor', () => {
   describe('requires arguments', () => {
     it('cannot be empty', () => {
@@ -76,5 +145,28 @@ describe('constructor', () => {
 
   it('returns an object', () => {
     expect(algoliaAlexaAdapter(args)).toEqual(expect.any(Object));
+  });
+
+  it('can handle state-based handlers', () => {
+    expect(() => { algoliaAlexaAdapter(argsWithState); }).not.toThrow();
+  });
+});
+
+describe('handler', () => {
+  describe('without state', () => {
+    it('executes without error', () => {
+      expect(() => {
+        algoliaAlexaAdapter(argsWithState).handler(req, {}, () => {});
+      }).not.toThrow();
+    });
+  });
+
+  describe('with state', () => {
+    req.session.attributes[Alexa.StateString] = state;
+    it('executes without error', () => {
+      expect(() => {
+        algoliaAlexaAdapter(argsWithState).handler(req, {}, () => {});
+      }).not.toThrow();
+    });
   });
 });

--- a/test/utils/build_handlers.test.js
+++ b/test/utils/build_handlers.test.js
@@ -1,0 +1,138 @@
+/* global
+  it, expect, describe, jest, beforeEach
+*/
+
+import buildHandlers from '../../src/utils/build_handlers.js';
+import {isArray, isObject} from '../../src/utils/is_of_type.js';
+import {StateString} from 'alexa-sdk';
+
+describe('handlers', () => {
+  const searchSpy = jest.fn(() => Promise.resolve());
+  const index = {
+    search: searchSpy,
+  };
+
+  const handlers = {
+    state: 'START_STATE',
+    LaunchRequest () {},
+    spyIntent: {
+      answerWith () {},
+    },
+    withParamsIntent: {
+      answerWith () {},
+      params: {
+        page: 10,
+      },
+    },
+    withParamsWithFunctionIntent: {
+      answerWith () {},
+      params: {
+        page (requestBody) {
+          return requestBody.request.intent.slots.page.value;
+        },
+      },
+    },
+    unChangedIntent () {},
+  };
+  const builtHandlers = buildHandlers(handlers, index, StateString);
+  const expectedQuery = 'query';
+  const scope = {
+    event: {
+      request: {
+        intent: {
+          slots: {
+            query: {
+              value: expectedQuery,
+            },
+            page: {
+              value: 5,
+            },
+          },
+        },
+      },
+    },
+  };
+
+  beforeEach(() => {
+    searchSpy.mockClear();
+  });
+
+  describe('when intent handler is specified', () => {
+    describe('in a single object', () => {
+      it('returns an array', () => {
+        expect(isArray(builtHandlers)).toBe(true);
+      });
+    });
+
+    describe('in an array of objects', () => {
+      const multipleHandlers = buildHandlers([handlers, handlers], index, StateString);
+
+      it('returns an array', () => {
+        expect(isArray(multipleHandlers)).toBe(true);
+      });
+
+      it('returns an array of objects', () => {
+        const allObjects = multipleHandlers.every(handler => isObject(handler));
+        expect(allObjects).toBe(true);
+      });
+    });
+
+    describe('is an object', () => {
+      it('has a state', () => {
+        expect(builtHandlers[0][StateString]).toEqual(handlers.state);
+      });
+
+      describe('with answerWith', () => {
+        describe('without params to merge', () => {
+          describe('when handler is invoked', () => {
+            it('searches Algolia', () => {
+              const expectedParams = {};
+
+              builtHandlers[0].spyIntent.call(scope);
+
+              expect(searchSpy).toHaveBeenCalledWith(expectedQuery, expectedParams);
+            });
+          });
+        });
+
+        describe('with params to merge', () => {
+          describe('when handler is invoked', () => {
+            it('searches Algolia with params', () => {
+              const expectedParams = {page: 10};
+
+              builtHandlers[0].withParamsIntent.call(scope);
+
+              expect(searchSpy).toHaveBeenCalledWith(expectedQuery, expectedParams);
+            });
+          });
+
+          describe('with params with function', () => {
+            const expectedParams = {page: 5};
+
+            builtHandlers[0].withParamsWithFunctionIntent.call(scope);
+
+            expect(searchSpy).toHaveBeenCalledWith(expectedQuery, expectedParams);
+          });
+        });
+      });
+
+      describe('without answerWith', () => {
+        it('throws an error', () => {
+          const newHandlers = {withoutAnswerWithIntent: {}};
+          Object.assign(newHandlers, handlers);
+
+          expect(() => {
+            buildHandlers(newHandlers, index);
+          }).toThrow();
+        });
+      });
+    });
+
+    describe('is a function', () => {
+      it('does not search Algolia', () => {
+        buildHandlers(handlers, index)[0].unChangedIntent();
+        expect(searchSpy).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/test/utils/is_of_type.test.js
+++ b/test/utils/is_of_type.test.js
@@ -2,7 +2,7 @@
   it, expect, describe
 */
 
-import {isOfType, isObject, isFunction} from '../../src/utils/is_of_type.js';
+import {isOfType, isObject, isFunction, isArray} from '../../src/utils/is_of_type.js';
 
 describe('isOfType', () => {
   it('returns a function', () => {
@@ -27,5 +27,15 @@ describe('isFunction', () => {
 
   it('return false if not a function', () => {
     expect(isFunction({})).toEqual(false);
+  });
+});
+
+describe('isArray', () => {
+  it('return true if a array', () => {
+    expect(isArray([])).toEqual(true);
+  });
+
+  it('return false if not a array', () => {
+    expect(isArray({})).toEqual(false);
   });
 });


### PR DESCRIPTION
This PR provides support for state handling on intents.

Background:
 - The Alexa Skills Kit has different states, each with a group of intents
 - For example, you can start with no state and triggering the HelpIntent will describe the overall skill
 - Once you enter a further state (e.g. `STARTED_GAME`) the HelpIntent might change to explain that step
 - The Alexa Skills Kit Node.js SDK handles states by emitting an event that corresponds to `${INTENT_NAME}${CURRENT_STATE}` that [has been registered](https://github.com/alexa/alexa-skills-kit-sdk-for-nodejs/blob/62e43964c457feb22eb4e44dc8eb154c6b0ee703/lib/alexa.js#L235)
 - It does that by looking at the `STATE` property on an object of handlers
   - (Currently `STATE`, but also exported as a property on the packaged module

This PR essentially takes a provided state and adds it to the built object that is then registered. It supports multiple objects (corresponding to multiple states) via a passing of an array of objects *or* a single state via passing a single object.