### PR TITLE
Handle intents without a query slot

### DIFF
--- a/src/utils/build_handlers.js
+++ b/src/utils/build_handlers.js
@@ -21,7 +21,11 @@ function buildFromObject(obj, index, stateString) {
       object[key] = function() {
         const args = {event: this.event};
         const params = buildParams(paramsObj, this.event);
-        const query = args.event.request.intent.slots.query ? args.event.request.intent.slots.query.value : '';
+        let query = '';
+        if (args.event.request.intent.slots && args.event.request.intent.slots.query) {
+          query = args.event.request.intent.slots.query.value;
+        }
+
         index
           .search(query, params)
           .then((results, err) => {

--- a/src/utils/build_handlers.js
+++ b/src/utils/build_handlers.js
@@ -21,8 +21,9 @@ function buildFromObject(obj, index, stateString) {
       object[key] = function() {
         const args = {event: this.event};
         const params = buildParams(paramsObj, this.event);
+        const query = args.event.request.intent.slots.query ? args.event.request.intent.slots.query.value : '';
         index
-          .search(args.event.request.intent.slots.query.value, params)
+          .search(query, params)
           .then((results, err) => {
             Object.assign(args, {err, results});
             func.call(this, args);

--- a/test/utils/build_handlers.test.js
+++ b/test/utils/build_handlers.test.js
@@ -84,10 +84,19 @@ describe('handlers', () => {
 
       describe('with answerWith', () => {
         describe('without params to merge', () => {
+          const expectedParams = {};
+
+          describe('without a query slot', () => {
+            const withoutQuery = JSON.parse(JSON.stringify(scope));
+            delete withoutQuery.event.request.intent.slots.query;
+
+            builtHandlers[0].spyIntent.call(withoutQuery);
+
+            expect(searchSpy).toHaveBeenCalledWith('', expectedParams);
+          });
+
           describe('when handler is invoked', () => {
             it('searches Algolia', () => {
-              const expectedParams = {};
-
               builtHandlers[0].spyIntent.call(scope);
 
               expect(searchSpy).toHaveBeenCalledWith(expectedQuery, expectedParams);

--- a/test/utils/build_handlers.test.js
+++ b/test/utils/build_handlers.test.js
@@ -88,7 +88,7 @@ describe('handlers', () => {
 
           describe('without a query slot', () => {
             const withoutQuery = JSON.parse(JSON.stringify(scope));
-            delete withoutQuery.event.request.intent.slots.query;
+            delete withoutQuery.event.request.intent.slots;
 
             builtHandlers[0].spyIntent.call(withoutQuery);
 


### PR DESCRIPTION
Fixes #18.

For intents without a query slot--perhaps just a facet, the adapter currently throws an error. This will, instead, pass an empty string. 