### PR TITLE
[RFC] Don't override the original params object when building

### DIFF
--- a/src/utils/build_params.js
+++ b/src/utils/build_params.js
@@ -8,14 +8,16 @@ export default function buildParams (params, event) {
   if (!isObject(params)) {
     throw new Error('params must be an object');
   }
-
-  for (const prop in params) {
-    if (params.hasOwnProperty(prop)) {
-      if (isFunction(params[prop])) {
-        params[prop] = params[prop](event);
+  
+  // Copy the params object, to avoid overriding the original keys/value pairs
+  const builtParams = Object.assign({}, params);
+  for (const prop in builtParams) {
+    if (builtParams.hasOwnProperty(prop)) {
+      if (isFunction(builtParams[prop])) {
+        builtParams[prop] = builtParams[prop](event);
       }
     }
   }
 
-  return params;
+  return builtParams;
 }


### PR DESCRIPTION
# Problem
I have been using this library lately to create an alexa skill for [Trouva](https://trouva.com) but noticed that when a Skill Intent is ran multiple times in a short period of time, the intent filters are not re-evaluated.

For example, I created the following Intent:
```
How many boutiques are in {area}?
```

When I calling that intent like so, caused the following incorrect behaviour:
1. `How many boutiques are in london?` (Correct: 126, Got: 126)
2. `How many boutiques are in manchester?` (Correct: 9, Got: 126)

# Debugging

**London call**
![screen shot 2017-09-03 at 22 30 36](https://user-images.githubusercontent.com/771903/30006815-53626be8-90f9-11e7-8003-1db6f2c54daf.png)

**Manchester call**
![screen shot 2017-09-03 at 22 30 51](https://user-images.githubusercontent.com/771903/30006819-680269ea-90f9-11e7-8c90-e3dadea21ccb.png)

I then placed a few `console.log`s in the `algoliasearch-alexa` library and found that the problem lies in the way that the `params` object is being evaluated in `utils/build_params.js`.

Placing a `console.log` just before [L12](https://github.com/algolia/algoliasearch-alexa/blob/master/src/utils/build_params.js#L12) produced the following output:
![screen shot 2017-09-03 at 22 32 06](https://user-images.githubusercontent.com/771903/30006846-163737de-90fa-11e7-8383-ed30afac5f4e.png)

**Notice the filters, changed from function to the previous evaluated output**

AWS seems to be re-using the same lambda functions to cut down on cold-boot times (which is awesome!) if the skill is called frequently.

# Fix

Instead of replacing the original `params` object [here](https://github.com/algolia/algoliasearch-alexa/blob/master/src/utils/build_params.js#L12-L18), copying the params object into a new object, and returning that, fixes the issue.