### PR TITLE
Add context (this) for param building functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ const handlers = {
     },
     params: {
       hitsPerPage: 1,
-      filters (requestBody) {
-        return `brand:${requestBody.request.intent.slots.brand.value}`;
+      filters (event, context) {
+        return `brand:${event.request.intent.slots.brand.value}`;
       }
     },
   },

--- a/src/utils/build_handlers.js
+++ b/src/utils/build_handlers.js
@@ -20,7 +20,7 @@ function buildFromObject(obj, index, stateString) {
 
       object[key] = function() {
         const args = {event: this.event};
-        const params = buildParams(paramsObj, this.event);
+        const params = buildParams(paramsObj, this.event, this);
         let query = '';
         if (args.event.request.intent.slots && args.event.request.intent.slots.query) {
           query = args.event.request.intent.slots.query.value;

--- a/src/utils/build_params.js
+++ b/src/utils/build_params.js
@@ -1,6 +1,6 @@
 import {isObject, isFunction} from './is_of_type.js';
 
-export default function buildParams (params, event) {
+export default function buildParams (params, event, context) {
   if (params === undefined || params === null) {
     return {};
   }
@@ -14,7 +14,7 @@ export default function buildParams (params, event) {
   for (const prop in builtParams) {
     if (builtParams.hasOwnProperty(prop)) {
       if (isFunction(builtParams[prop])) {
-        builtParams[prop] = builtParams[prop](event);
+        builtParams[prop] = builtParams[prop](event, context);
       }
     }
   }


### PR DESCRIPTION
This provides the capability to build params based on state or user attributes, which are not available on the event object.